### PR TITLE
Make $dirs and $files protected in FileList

### DIFF
--- a/src/filesystem/filelist/FileList.php
+++ b/src/filesystem/filelist/FileList.php
@@ -35,10 +35,10 @@
  * @task test   Testing File Lists
  * @group filesystem
  */
-final class FileList {
+class FileList {
 
-  private $files = array();
-  private $dirs  = array();
+  protected $files = array();
+  protected $dirs  = array();
 
   /**
    * Build a new FileList from an array of paths, e.g. from $argv.


### PR DESCRIPTION
Summary:
Make $dirs and $files protected in FileList to allow functionality
extension by inheritance.

Test Plan:
php -l
git grep "extends FileSystem" to check if there are children classes.
