### PR TITLE
static scalar for xhp attribute default value

### DIFF
--- a/src/parser/xhpast/bin/xhpast_parse.php
+++ b/src/parser/xhpast/bin/xhpast_parse.php
@@ -29,7 +29,7 @@ function xhpast_is_available() {
       list($err, $stdout) = exec_manual('%s --version', $bin);
       if (!$err) {
         $version = trim($stdout);
-        if ($version === "xhpast version 0.57") {
+        if ($version === "xhpast version 0.58") {
           $available = true;
         }
       }

--- a/src/parser/xhpast/constants/parser_nodes.php
+++ b/src/parser/xhpast/constants/parser_nodes.php
@@ -120,5 +120,7 @@ function xhp_parser_node_constants() {
     9113 => 'n_XHP_NODE_LIST',
     9114 => 'n_CONCATENATION_LIST',
     9115 => 'n_PARENTHETICAL_EXPRESSION',
+    9116 => 'n_YIELD',
+    9117 => 'n_YIELD_EXPRESSION',
   );
 }

--- a/support/xhpast/parser.y
+++ b/support/xhpast/parser.y
@@ -15,6 +15,11 @@
  */
 
 %{
+/*
+ * If you modify this grammar, please update the version number in
+ * ./xhpast.cpp and libphutil/src/parser/xhpast/bin/xhpast_parse.php
+ */
+ 
 #include "ast.hpp"
 #include "node_names.hpp"
 // PHP's if/else rules use right reduction rather than left reduction which
@@ -2797,11 +2802,7 @@ xhp_attribute_enum:
 ;
 
 xhp_attribute_default:
-  '=' common_scalar {
-//!    $2.strip_lines();
-//!    $$ = $2;
-  }
-| '=' T_STRING {
+  '=' static_scalar {
 //!    $2.strip_lines();
 //!    $$ = $2;
   }

--- a/support/xhpast/xhpast.cpp
+++ b/support/xhpast/xhpast.cpp
@@ -31,7 +31,8 @@ int main(int argc, char* argv[]) {
   vector<string> files;
 
   if (argc != 1) {
-    cout << "xhpast version 0.57\n";
+    //coupling: modify also libphutil/src/parser/xhpast/bin/xhpast_parse.php
+    cout << "xhpast version 0.58\n";
     return 0;
   }
 


### PR DESCRIPTION
Test Plan:
cat test.php | ./xhpast
where test.php is:
  <?php

  class Foo {
    const CST = 1;
  }

  class :x:foo {
    attribute
      int padding = Foo::CST,
      ;
  }

Reviewed By: epriestley
Reviewers: epriestley, marcel
CC: aran, pad, epriestley
Revert Plan:
Tags:
- begin _PUBLIC_ platform impact section -
  Bugzilla: #
- end platform impact -

Differential Revision: 232
