### PR TITLE
Objective-C++ support for Pygments

### DIFF
--- a/src/markup/syntax/highlighter/pygments/PhutilPygmentsSyntaxHighlighter.php
+++ b/src/markup/syntax/highlighter/pygments/PhutilPygmentsSyntaxHighlighter.php
@@ -136,6 +136,7 @@ final class PhutilPygmentsSyntaxHighlighter {
       'GNUmakefile' => 'make',
       'mao' => 'mako',
       'm' => 'objective-c',
+      'mm' => 'objective-c',
       'mhtml' => 'mason',
       'mc' => 'mason',
       'mi' => 'mason',


### PR DESCRIPTION
Summary:
Objective-C files come in two flavors (.m for Objective-C,
.mm for Objective-C++).  This updates the Pygments syntax
highlighter to handle Objective-C++ files.

Test Plan: Inspection.

Reviewers: epriestley, btrahan

Reviewed By: epriestley

CC: aran, epriestley

Differential Revision: https://secure.phabricator.com/D1569
