### PR TITLE
D3086

### DIFF
--- a/src/markup/syntax/highlighter/PhutilPygmentsSyntaxHighlighter.php
+++ b/src/markup/syntax/highlighter/PhutilPygmentsSyntaxHighlighter.php
@@ -97,6 +97,8 @@ final class PhutilPygmentsSyntaxHighlighter {
       'c++-objdump' => 'cpp-objdump',
       'cxx-objdump' => 'cpp-objdump',
       'cs' => 'csharp',
+      'less' => 'css',
+      'scss' => 'css',
       'pyx' => 'cython',
       'pxd' => 'cython',
       'pxi' => 'cython',


### PR DESCRIPTION
Summary:
LESS and SCSS are two stylesheet languages similar in syntax to CSS.
Pygments doesn't directly support them, but I don't think it's unreasonable to
highlight them as CSS by default. They're close enough to CSS that it doesn't
look terrible, and I think they're becoming used enough that it makes sense
to do this by default.

Test Plan:
Viewed a .less, and .scss file under the CSS parser to see if they looked
reasonable.

See P473 (scss) and P474 (less) for samples of them highlighted with css.

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3086
