### PR TITLE
Work-around the lookbehind pcre bug

### DIFF
--- a/src/console/PhutilConsoleFormatter.php
+++ b/src/console/PhutilConsoleFormatter.php
@@ -57,9 +57,9 @@ final class PhutilConsoleFormatter {
 
     // Sequence should be preceded by start-of-string or non-backslash
     // escaping.
-    $bold_re      = '/(?<=^|[^\\\\])\*\*(.*)\*\*/sU';
-    $underline_re = '/(?<=^|[^\\\\])__(.*)__/sU';
-    $invert_re    = '/(?<=^|[^\\\\])##(.*)##/sU';
+    $bold_re      = '/(?<![\\\\])\*\*(.*)\*\*/sU';
+    $underline_re = '/(?<![\\\\])__(.*)__/sU';
+    $invert_re    = '/(?<![\\\\])##(.*)##/sU';
 
     if (self::getDisableANSI()) {
       $format = preg_replace($bold_re,      '\1',   $format);


### PR DESCRIPTION
There is a bug in older versions of pcre, including the ones used on all RHEL5x based distros, that prevents from using negetaion in character class match inside lookbehind.

This simple change to negative lookbehind fixes it, however there is no lookbehind for positive match for ^. I don't think this is a problem though - the logic of such a check is not clear to me. The regex reads: look for pattern preceded by ^ OR preceded by NOT slash. But ^ satisfies the NOT slash condition. I am probably missing something but I'm not aware of any negative consequences of such a change.

Phabricator issue 179 (https://github.com/facebook/phabricator/issues/179)
