### PR TITLE
D3953

### DIFF
--- a/src/future/http/status/HTTPFutureResponseStatusCURL.php
+++ b/src/future/http/status/HTTPFutureResponseStatusCURL.php
@@ -51,8 +51,8 @@ final class HTTPFutureResponseStatusCURL extends HTTPFutureResponseStatus {
       // CURLE_SSL_CACERT_BADFILE but there's no corresponding constant in
       // PHP.
       77 =>
-        'The SSL CA Bundle "libphutil/resources/ssl/custom.pem" could not '.
-        'be read or is not formatted correctly.',
+        'The SSL CA Bundles that we tried to use could not be read or are '.
+        'not formatted correctly.',
 
       CURLE_SSL_CONNECT_ERROR =>
         'There was an error negotiating the SSL connection. This usually '.


### PR DESCRIPTION
Summary:
This patch provides a better fallback path for SSL certificates in libphutil.
The path now works like this:
- See if a certificate has been set externally (e.g. by arcanist -- I'll get to
  this in a minute).
- See if a custom.pem exists. This provides another "local" option before we ask
  the system for a global option.
- Ask php if curl.cainfo is set, and use that.
- Lastly, fall back to default.pem, which ships with libphutil.

As for setting the certificate externally -- I'd like to (next) patch Arcanist
to accept an "ssl_cert" key in .arcrc, for specific hosts, and use it if it
exists. The ssl cert there will be the full certificate. It prevents the user
from having to maintain bundles of certs themselves. It also allows for saner
fallback -- e.g. if I use arc for both secure.phabricator.com and my own
instance with a custom cert -- previously Phabricator would try to use
`custom.pem` for both. This patch provides a //way// to fix that issue, and a
patch to Arcanist will provide the actual fix.

Test Plan:
Lots of stuff. :)
- Threw a custom.pem in `libphutil/resources/ssl`, and it tried to use it.
- Added a `curl.cainfo` and saw that it wasn't used (custom.pem takes
  precedence).
- Moved the custom.pem out of the way, and saw that `curl.cainfo` was now used.
- Removed `curl.cainfo` and saw it fall back to default.pem.

Reviewers: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3953
