### PR TITLE
Fix a bug for Filesystem.resolvePath method in windows xp system.

### DIFF
--- a/src/filesystem/Filesystem.php
+++ b/src/filesystem/Filesystem.php
@@ -677,7 +677,7 @@ final class Filesystem {
    */
   public static function resolvePath($path, $relative_to = null) {
     if (phutil_is_windows()) {
-      $is_absolute = preg_match('/^[A-Z]+:/', $path);
+      $is_absolute = preg_match('/^[A-Za-z]+:/', $path);
     } else {
       $is_absolute = !strncmp($path, DIRECTORY_SEPARATOR, 1);
     }


### PR DESCRIPTION
Hi, I'm user of phabricator. I use arcanist to push my change to server. but now, I got an "Failed to create a temporary directory." error when I do it in my Windows XP system.

I found this bug is caused by my local temporal path is "d:\temp", the Filesystem.resolvePath method consider it as a relative path, so, it be adjust to "c:\path\to\phabricator\d:\temp" and throw error like above. 

I had try to fix it in my branch. could you please merge it into your branch to help others like me.

thinks.
