### PR TITLE
adding port parameter to the mysqli instantiation

### DIFF
--- a/src/aphront/storage/connection/mysql/AphrontMySQLDatabaseConnection.php
+++ b/src/aphront/storage/connection/mysql/AphrontMySQLDatabaseConnection.php
@@ -39,7 +39,7 @@ final class AphrontMySQLDatabaseConnection
 
     // if there isn't a port in the host, and it isn't a socket address (starts with /) 
     // and there is a port configuration, append the port to the host name
-    if (strpos($host, ':') === false && substr($host, 0, 1) != '/' && !empty($port) ) {
+    if (!empty($port)) {
       $host .= ':'.$port;
     }
 

--- a/src/aphront/storage/connection/mysql/AphrontMySQLiDatabaseConnection.php
+++ b/src/aphront/storage/connection/mysql/AphrontMySQLiDatabaseConnection.php
@@ -34,16 +34,6 @@ final class AphrontMySQLiDatabaseConnection
     $user = $this->getConfiguration('user');
     $host = $this->getConfiguration('host');
     $port = $this->getConfiguration('port');
-
-    // if there is a port in the host, pull it out and set it to the port variable
-    if (strpos($host, ':') !== false) {
-      $hostPieces = explode(':', $host);
-      $host = $hostPieces[0];
-      if (is_numeric($host[1])) {
-        $port = $hostPieces[1];
-      }
-    }
-
     $database = $this->getConfiguration('database');
 
     $pass = $this->getConfiguration('pass');


### PR DESCRIPTION
mysqli passes the port in as a parameter versus mysql_connect()'s method of using the hostname http://localhost:8889. http://www.php.net/manual/en/mysqli.construct.php This change will allow you to specify a port in the config that gets used when setting up the connection. I found it useful when utilizing this with MAMP when the default port is 8889 for MySQL.

Related phabricator change to support ports: https://github.com/facebook/phabricator/pull/356
