### PR TITLE
Add color output support for supported platforms on Windows

### DIFF
--- a/src/console/PhutilConsoleFormatter.php
+++ b/src/console/PhutilConsoleFormatter.php
@@ -25,8 +25,8 @@ final class PhutilConsoleFormatter {
 
   public static function getDisableANSI() {
     if (self::$disableANSI === null) {
-      $term = getenv("term");
-      if (phutil_is_windows() && $term !== "cygwin" && $term !== "ANSI") {
+      $term = strtolower(getenv("TERM"));
+      if (phutil_is_windows() && $term !== "cygwin" && $term !== "ansi") {
         self::$disableANSI = true;
       } else if (function_exists('posix_isatty') && !posix_isatty(STDOUT)) {
         self::$disableANSI = true;


### PR DESCRIPTION
Modifies the `disableANSI` code to not outright reject Windows
but check the `TERM` environment variable in case it supports
ANSI colors. This applies to CygWin, PowerShell and integrated
terminals such as the ones in IntelliJ IDEs.

Tested manually in PowerShell, ConEmu and `cmd.exe`.
