### PR TITLE
Update account image retrieval for Google+ API

### DIFF
--- a/src/auth/PhutilGoogleAuthAdapter.php
+++ b/src/auth/PhutilGoogleAuthAdapter.php
@@ -40,7 +40,8 @@ final class PhutilGoogleAuthAdapter extends PhutilOAuthAuthAdapter {
   }
 
   public function getAccountImageURI() {
-    return $this->getOAuthAccountData('picture');
+    $image = $this->getOAuthAccountData('image', array());
+    return idx($image, 'url');
   }
 
   public function getAccountURI() {


### PR DESCRIPTION
Google+ APIs have probably changed since the original code was written. This change adheres to the Google+ API as of writing.

### Extra
The url returned by Google is usually of that of a small image. The size can be changed by modifying a URL query param, but to rebuild the query I have to either concatenate everything in the parsed url, or use `http_build_url`, thus adding a dependency on the PHP `pecl-http` extension. Directions with regard to this decision would be appreciated.