### PR TITLE
Fix order of arguments passed to `implode()' ($glue, $pieces)

### DIFF
--- a/src/utils/utils.php
+++ b/src/utils/utils.php
@@ -1703,7 +1703,7 @@ function phutil_build_http_querystring_from_pairs(array $pairs) {
     list($key, $value) = phutil_http_parameter_pair($key, $value);
     $query[] = rawurlencode($key).'='.rawurlencode($value);
   }
-  $query = implode($query, '&');
+  $query = implode('&', $query);
 
   return $query;
 }


### PR DESCRIPTION
to avoid warnings on newer versions of PHP.

See also:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240931
https://www.php.net/manual/en/function.implode.php